### PR TITLE
Fix the promt typo

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 from datetime import datetime
 
 
-class Promt(BaseModel):
+class Prompt(BaseModel):
     id: int
     agent_name: str
-    promt: str
+    prompt: str
     created_at: datetime
 
 
-class PromtCreate(BaseModel):
+class PromptCreate(BaseModel):
     agent_name: str | None
-    promt: str
+    prompt: str


### PR DESCRIPTION
This was pointed out by @iita-mari in earlier PR, but we did not fix it then.

I just changed this schemas.py file. It seems like these two classes are not imported/used anywhere so other files did not have to be changed. @liinu-a what is this file for anyways?