### PR TITLE
Write migration script for prompt table creation

### DIFF
--- a/backend/app/db/alembic-conf/versions/2025_10_23_1721-b4335f12c0f6_initial_migration.py
+++ b/backend/app/db/alembic-conf/versions/2025_10_23_1721-b4335f12c0f6_initial_migration.py
@@ -24,6 +24,7 @@ def upgrade() -> None:
     op.create_table(
         "prompt",
         Column("id", Integer, primary_key=True),
+        Column("user", String()),
         Column("agent_name", String(50), server_default="unknown"),
         Column("prompt", String(4000), nullable=False),
         Column("created_at", DateTime(timezone=True), server_default=func.now()),

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -14,6 +14,7 @@ class Prompt(Base):
     __tablename__ = "prompt"
 
     id: Mapped[int] = mapped_column(primary_key=True)
+    user: Mapped[str]
     agent_name: Mapped[str] = mapped_column(String(50), server_default="unknown")
     prompt: Mapped[str] = mapped_column(String(4000), nullable=False)
     created_at: Mapped[datetime] = mapped_column(


### PR DESCRIPTION
An initial migration script, which creates a database table for storing prompts.

A new migration file can be created by moving to the doubleAgent/backend/app/db folder and then running the command

`alembic revision -m '<a descriptive message>'`

The newly created migration file will be placed into the doubleAgent/backend/app/db/alembic-conf/versions folder. The file will include empty upgrade() and downgrade() functions. At least the upgrade() function should be populated with directives that will apply a set of changes to the db.
For more information, see the [Alembic documentation](https://alembic.sqlalchemy.org/en/latest/tutorial.html).