### PR TITLE
Configure create_engine (db) better for supabase

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -12,9 +12,7 @@ if DATABASE_URL is None:
 
 app_env = os.getenv("DA_ENVIRONMENT", "production").lower()
 
-engine_args = {
-    "echo": True
-}
+engine_args = {"echo": True}
 
 if app_env == "development":
     print("INFO: Running in 'development' mode, using NullPool (for supabase reasons).")


### PR DESCRIPTION
Without poolclass=pool.NullPool there might be issues later on. It worked without too but according to gemini its very buggy to use supabase without NullPool definition.