### PR TITLE
Allow setting and saving longer prompts

### DIFF
--- a/backend/app/db/alembic-conf/versions/2025_11_23_1330-09384c062e72_lengthen_prompt_column_of_prompt_table.py
+++ b/backend/app/db/alembic-conf/versions/2025_11_23_1330-09384c062e72_lengthen_prompt_column_of_prompt_table.py
@@ -1,0 +1,52 @@
+"""Lengthen the prompt column of the prompt table.
+Additionally, set the nullable value of the user column to false.
+
+Revision ID: 09384c062e72
+Revises: b4335f12c0f6
+Create Date: 2025-11-23 13:30:12.294128
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "09384c062e72"
+down_revision: Union[str, Sequence[str], None] = "b4335f12c0f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        table_name="prompt",
+        column_name="prompt",
+        existing_type=sa.String(length=4000),
+        type_=sa.String(length=15000),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        table_name="prompt",
+        column_name="user",
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column(
+        table_name="prompt",
+        column_name="prompt",
+        existing_type=sa.String(length=15000),
+        type_=sa.String(length=4000),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        table_name="prompt",
+        column_name="user",
+        nullable=True,
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -14,9 +14,9 @@ class Prompt(Base):
     __tablename__ = "prompt"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user: Mapped[str]
+    user: Mapped[str] = mapped_column(String(), nullable=False)
     agent_name: Mapped[str] = mapped_column(String(50), server_default="unknown")
-    prompt: Mapped[str] = mapped_column(String(4000), nullable=False)
+    prompt: Mapped[str] = mapped_column(String(15000), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,4 +12,4 @@ class Prompt(BaseModel):
 
 class SavePrompt(BaseModel):
     agent_name: str | None = Field(max_length=50)
-    prompt: str = Field(max_length=4000, min_length=1)
+    prompt: str = Field(max_length=15000, min_length=1)

--- a/frontend/src/components/PromptEditorModal.jsx
+++ b/frontend/src/components/PromptEditorModal.jsx
@@ -38,7 +38,7 @@ const PromptEditorModal = ({ modalRef, currentPrompt, onSetPrompt, onClose }) =>
           <textarea
             value={text}
             onChange={(e) => setText(e.target.value)}
-            maxLength={4000}
+            maxLength={15000}
             required
             id="promptText"
             className="textarea textarea-bordered w-full h-40"


### PR DESCRIPTION
Created a migration script that raises the max length of the prompt table's prompt column. Also changed parts of the code to allow the saving and setting of longer prompts.

Ran the migration script on the test db and tested saving and setting an extra long prompt (around 15000 characters), which worked. 

Additionally, set the nullable value of the user column to false.