### PR TITLE
Fix most recently saved prompts being at the bottom

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -247,7 +247,11 @@ async def get_prompts(
     user: str = Depends(get_user_id),
     db: Session = Depends(get_db),
 ):
-    prompts = db.scalars(select(models.Prompt).where(models.Prompt.user == user)).all()
+    prompts = db.scalars(
+        select(models.Prompt)
+        .where(models.Prompt.user == user)
+        .order_by(models.Prompt.created_at.desc())
+    ).all()
 
     return prompts
 

--- a/frontend/src/components/PromptManagerModal.jsx
+++ b/frontend/src/components/PromptManagerModal.jsx
@@ -97,7 +97,7 @@ export const PromptEditor = ({
       const prompt = res.data;
 
       onSetPrompt(prompt);
-      setSavedPrompts((prev) => new Map(prev.set(prompt.id, prompt)));
+      setSavedPrompts((prev) => new Map([[prompt.id, prompt], ...prev]));
       onClose();
       showAlert(`Prompt ${promptData.id ? 'edited' : 'created'} and set.`, 'success');
     } catch (err) {


### PR DESCRIPTION
The prompt order was oldest on top in the modal where the saved prompts are listed. Also if a new prompt was saved, it would go to the bottom. This should fix the issues.