### PR TITLE
Add hyGroupCn validation for OIDC login

### DIFF
--- a/backend/app/routers/oidc_router.py
+++ b/backend/app/routers/oidc_router.py
@@ -11,7 +11,7 @@ DA_OIDC_CLIENT_SECRET = os.getenv("DA_OIDC_CLIENT_SECRET")
 DA_OIDC_REDIRECT_URI = os.getenv("DA_OIDC_REDIRECT_URI")
 DA_ALLOWED_GROUP = os.getenv("DA_ALLOWED_GROUP", "grp-doubleagent")
 # Parse boolean from DA_ENFORCE_GROUP_CHECK env var (temporary for testing)
-ENFORCE_GROUP_CHECK = os.getenv("DA_ENFORCE_GROUP_CHECK", "true").lower() == "true"
+isGroupCheckEnforced = os.getenv("DA_ENFORCE_GROUP_CHECK", "true").lower() == "true"
 
 oauth = OAuth()
 
@@ -50,7 +50,7 @@ async def auth_callback(request: Request):
         # Check if user belongs to the allowed group
         user_group = userinfo.get("hyGroupCn")
 
-        if ENFORCE_GROUP_CHECK:
+        if isGroupCheckEnforced:
             if not user_group:
                 print(
                     f"Login denied: No hyGroupCn found for user {userinfo.get('sub')}"


### PR DESCRIPTION
Allows us to login if it fails again but the debug will tell the correct hyGroupCn attribute name and structure in the userinfo response. Even though I am pretty sure it works now.